### PR TITLE
Add email, grades, tenant_id to Student Type

### DIFF
--- a/lib/types/student.rb
+++ b/lib/types/student.rb
@@ -6,7 +6,11 @@ module OneRoster
       attr_reader :uid,
                   :first_name,
                   :last_name,
-                  :provider
+                  :usename,
+                  :provider,
+                  :email,
+                  :grades,
+                  :tenant_id
 
       def initialize(attributes = {}, client: nil)
         @uid          = attributes['sourcedId']
@@ -16,6 +20,8 @@ module OneRoster
         @email        = attributes['email']
         @username     = username(client)
         @provider     = 'oneroster'
+        @grades       = attributes['grades']
+        @tenant_id    = attributes.dig("orgs", 0, "sourcedId")
       end
 
       def username(client = nil)
@@ -30,8 +36,11 @@ module OneRoster
           first_name: @first_name,
           last_name: @last_name,
           username: @username,
-          provider: @provider
-        }
+          provider: @provider,
+          email: @email,
+          grades: @grades,
+          tenant_id: @tenant_id
+}
       end
 
       private

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -67,12 +67,14 @@ RSpec.describe OneRoster::Client do
         expect(first_student.first_name).to eq(student_1['givenName'])
         expect(first_student.last_name).to eq(student_1['familyName'])
         expect(first_student.username).to eq(student_1['sourcedId'])
+        expect(first_student.email).to eq(student_1['email'])
         expect(first_student.provider).to eq('oneroster')
 
         expect(second_student).to be_a(OneRoster::Types::Student)
         expect(second_student.uid).to eq(student_3['sourcedId'])
         expect(second_student.first_name).to eq(student_3['givenName'])
         expect(second_student.last_name).to eq(student_3['familyName'])
+        expect(second_student.email).to eq(student_3['email'])
         expect(second_student.username).to eq(student_3['email'])
         expect(second_student.provider).to eq('oneroster')
       end
@@ -691,7 +693,10 @@ RSpec.describe OneRoster::Client do
           first_name: student_1['givenName'],
           last_name: student_1['familyName'],
           username: student_1['sourcedId'],
-          provider: 'oneroster'
+          provider: 'oneroster',
+          email: student_1['email'],
+          grades: student_1['grades'],
+          tenant_id: nil
         )
       end
     end


### PR DESCRIPTION
We want to add email, grades and tenant_id (aka org.sourcedId) to the Student type when we import from classlink.  So this PR does that.

FYI, there are four specs that fail in master that I did not fix.   I did adjust two specs that were not failing to reflect the changes in this PR.
