### PR TITLE
Revised tenant_id and school_id

### DIFF
--- a/lib/one_roster/client.rb
+++ b/lib/one_roster/client.rb
@@ -84,7 +84,8 @@ module OneRoster
           'term_end_date' => term&.end_date,
           'term_id' => oneroster_class.term_id,
           'school_name' => school&.name,
-          'school_uid' => school&.uid
+          'school_uid' => school&.uid,
+          'tenant_id' => school&.tenant_id
         )
       end
     end

--- a/lib/types/classroom.rb
+++ b/lib/types/classroom.rb
@@ -15,7 +15,8 @@ module OneRoster
                   :term_end_date,
                   :term_id,
                   :school_name,
-                  :school_uid
+                  :school_uid,
+                  :tenant_id
 
       def initialize(attributes = {})
         @uid             = attributes['id']
@@ -30,6 +31,7 @@ module OneRoster
         @term_id         = attributes['term_id']
         @school_name     = attributes['school_name']
         @school_uid      = attributes['school_uid']
+        @tenant_id       = attributes['tenant_id']
         @provider        = 'oneroster'
       end
     end

--- a/lib/types/school.rb
+++ b/lib/types/school.rb
@@ -2,7 +2,7 @@
 
 module OneRoster
   module Types
-    class Tenant
+    class School
       attr_reader :uid, :name, :number, :tenant_id
 
       def initialize(attributes = {}, *)

--- a/lib/types/school.rb
+++ b/lib/types/school.rb
@@ -2,14 +2,22 @@
 
 module OneRoster
   module Types
-    class School
-      attr_reader :uid, :name, :number
+    class Tenant
+      attr_reader :uid, :name, :number, :tenant_id
 
       def initialize(attributes = {}, *)
         @uid      = attributes['sourcedId']
         @name     = attributes['name']
         @number   = attributes['identifier']
         @provider = 'oneroster'
+        @tenant_id = tenant_id_from(attributes)
+      end
+
+      def tenant_id_from(attributes)
+        orgs = attributes.dig("parent")
+        return unless orgs && orgs.is_a?(Array)
+
+        orgs.filter{ |org| org["type"] == "org"}.first&.dig("sourcedId")
       end
     end
   end

--- a/lib/types/student.rb
+++ b/lib/types/student.rb
@@ -18,6 +18,7 @@ module OneRoster
         @last_name    = attributes['familyName']
         @status       = attributes['status']
         @email        = attributes['email']
+        @api_username = attributes['username']
         @username     = username(client)
         @provider     = 'oneroster'
         @grades       = attributes['grades']

--- a/lib/types/student.rb
+++ b/lib/types/student.rb
@@ -21,13 +21,20 @@ module OneRoster
         @username     = username(client)
         @provider     = 'oneroster'
         @grades       = attributes['grades']
-        @tenant_id    = attributes.dig("orgs", 0, "sourcedId")
+        @tenant_id    = tenant_id_from(attributes)
       end
 
       def username(client = nil)
         username_source = client&.username_source
 
         @username ||= presence(username_from(username_source)) || default_username
+      end
+
+      def tenant_id_from(attributes)
+        orgs = attributes.dig("orgs")
+        return unless orgs && orgs.is_a?(Array)
+
+        orgs.filter{ |org| org["type"] == "org"}.first&.dig("sourcedId")
       end
 
       def to_h

--- a/lib/types/student.rb
+++ b/lib/types/student.rb
@@ -10,7 +10,7 @@ module OneRoster
                   :provider,
                   :email,
                   :grades,
-                  :tenant_id
+                  :school_id
 
       def initialize(attributes = {}, client: nil)
         @uid          = attributes['sourcedId']
@@ -21,7 +21,7 @@ module OneRoster
         @username     = username(client)
         @provider     = 'oneroster'
         @grades       = attributes['grades']
-        @tenant_id    = tenant_id_from(attributes)
+        @school_id    = school_id_from(attributes)
       end
 
       def username(client = nil)
@@ -30,7 +30,7 @@ module OneRoster
         @username ||= presence(username_from(username_source)) || default_username
       end
 
-      def tenant_id_from(attributes)
+      def school_id_from(attributes)
         orgs = attributes.dig("orgs")
         return unless orgs && orgs.is_a?(Array)
 
@@ -46,7 +46,7 @@ module OneRoster
           provider: @provider,
           email: @email,
           grades: @grades,
-          tenant_id: @tenant_id
+          school_id: @school_id
 }
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -355,6 +355,8 @@ RSpec.describe OneRoster::Client do
         expect(first_classroom.course_number).to eq(course_1['courseCode'])
         expect(first_classroom.period).to eq('1')
         expect(first_classroom.grades).to eq(class_1['grades'])
+        expect(first_classroom.tenant_id).to eq(class_1['tenant_id'])
+        expect(first_classroom.school_id).to eq(class_1['school_id'])
         expect(first_classroom.subjects).to eq([])
         expect(first_classroom.term_name).to eq('term name')
         expect(first_classroom.term_start_date).to eq('2019-08-21')

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -696,7 +696,7 @@ RSpec.describe OneRoster::Client do
           provider: 'oneroster',
           email: student_1['email'],
           grades: student_1['grades'],
-          tenant_id: nil
+          school_id: nil
         )
       end
     end

--- a/spec/support/api_responses.rb
+++ b/spec/support/api_responses.rb
@@ -252,7 +252,9 @@ RSpec.shared_context 'api responses' do
       'periods' => %w(1 2),
       'grades' => %w(04 05),
       'junk' => 'data',
-      'terms' => [{ 'sourcedId' => '1' }]
+      'terms' => [{ 'sourcedId' => '1' }],
+      'tenant_id' => 'tenant_id',
+      'school_id' => 'school_id'
     }
   end
 


### PR DESCRIPTION
In an earlier PR we set the org tenant_id on the student object.   But it turned out that that was not the org tenant_id but rather it was only the school_id.   However, the org tenant_id is available at the school and classroom level so this PR sets the tenant_id on school and classroom.   And it renames the tenant_id on the student to be school_id.