### PR TITLE
Fix tenant_id in school type

### DIFF
--- a/lib/types/school.rb
+++ b/lib/types/school.rb
@@ -10,14 +10,7 @@ module OneRoster
         @name     = attributes['name']
         @number   = attributes['identifier']
         @provider = 'oneroster'
-        @tenant_id = tenant_id_from(attributes)
-      end
-
-      def tenant_id_from(attributes)
-        orgs = attributes.dig("parent")
-        return unless orgs && orgs.is_a?(Array)
-
-        orgs.filter{ |org| org["type"] == "org"}.first&.dig("sourcedId")
+        @tenant_id = attributes.dig("parent", "sourcedId")
       end
     end
   end


### PR DESCRIPTION
I made a mistake in a previous PR.   The "parent" attribute in the school data is not an array but an object.  So this PR fixes that.

To test
- load this PR locally
-  in core terminal: `bundle config local.oneroster ../OneRoster`  or to whatever your local path is to the gem
- `bundle install`
- in the console you should be able to call the schools endpoint of the client and get a tenant_id
```
[1] pry(main)> client=ClassLinkRoster::Client.new(OneRosterConfiguration.first.organization)
[2] pry(main)> r=client.client.schools
=> [#<OneRoster::Types::School:0x00000001626022b0 @name="ClassLink HS", @number="123456789123", @provider="oneroster", @tenant_id="10", @uid="12">,
 #<OneRoster::Types::School:0x0000000162602260 @name="ClassLink MS", @number="123456789456", @provider="oneroster", @tenant_id="10", @uid="13">,
 #<OneRoster::Types::School:0x0000000162602210 @name="ClassLink ES", @number="123456789789", @provider="oneroster", @tenant_id="10", @uid="17">,
 #<OneRoster::Types::School:0x00000001626021c0 @name="eSpark", @number="3167", @provider="oneroster", @tenant_id="10", @uid="3167">,
 #<OneRoster::Types::School:0x0000000162602170 @name="eSpark-2", @number="3167-2", @provider="oneroster", @tenant_id="10", @uid="3167-2">,
 #<OneRoster::Types::School:0x0000000162602120 @name="(QATeam)", @number="QATeam", @provider="oneroster", @tenant_id="10", @uid="QATeam">,
 #<OneRoster::Types::School:0x00000001626020d0 @name="(QATeam)-2", @number="QATeam-2", @provider="oneroster", @tenant_id="10", @uid="QATeam-2">]
[3] pry(main)> r.first.tenant_id
=> "10"
```
- to restore the gem: `bundle config --delete local.oneroster`
- if you want to examine the structure of the attributes from OneRoster you can put a binding pry above the refactored code and then run `bundle install` again on the core terminal and reload the console to test again.