### PR TITLE
update branch targets for renaming default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
I renamed the master branch => main in Github's UI, this update the targets branches for the CI job to run.